### PR TITLE
Added resource update guidance

### DIFF
--- a/input/fsh/Examples/AllergyIntolerance-example.fsh
+++ b/input/fsh/Examples/AllergyIntolerance-example.fsh
@@ -5,6 +5,9 @@ Description: "An example payload for a Primary Care AllergyIntolerance resource 
 * meta.lastUpdated = "2024-01-26T10:03:26+13:00"
 * meta insert HPIFacility(F38006-B)
 //* meta.profile = $SDHRAllergyIntoleranceProfile
+
+* insert LocalIdentifierExample
+
 * type = #allergy
 * clinicalStatus = http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical#active "Active"
 * verificationStatus = http://terminology.hl7.org/CodeSystem/allergyintolerance-verification#confirmed "Confirmed"

--- a/input/fsh/Examples/Encounter-example.fsh
+++ b/input/fsh/Examples/Encounter-example.fsh
@@ -6,6 +6,8 @@ Usage: #example
 
 * meta insert HPIFacility(F38006-B)
 
+* insert LocalIdentifierExample
+
 * subject insert PatientSubject(ZKC7284, Carrey Carrington)
 
 * identifier.system = $HealthRecordKey

--- a/input/fsh/Examples/Encounter-example.fsh
+++ b/input/fsh/Examples/Encounter-example.fsh
@@ -10,8 +10,8 @@ Usage: #example
 
 * subject insert PatientSubject(ZKC7284, Carrey Carrington)
 
-* identifier.system = $HealthRecordKey
-* identifier.value = "f4121d2e-61aa-4222-83ae-b36d26bbbe62"
+* identifier[+].system = $HealthRecordKey
+* identifier[=].value = "f4121d2e-61aa-4222-83ae-b36d26bbbe62"
 * serviceType = http://terminology.hl7.org/CodeSystem/service-type#124 "General Practice"
 
 * status = #finished

--- a/input/fsh/Examples/Hypertension-Condition-example.fsh
+++ b/input/fsh/Examples/Hypertension-Condition-example.fsh
@@ -6,6 +6,8 @@ Usage: #example
 
 * meta insert HPIFacility(F38006-B)
 
+* insert LocalIdentifierExample
+
 * extension.url = "http://hl7.org.nz/fhir/StructureDefinition/long-term-condition"
 * extension.valueBoolean = true
 * clinicalStatus = $condition-clinical#active

--- a/input/fsh/Examples/Observation-VitalSigns-example.fsh
+++ b/input/fsh/Examples/Observation-VitalSigns-example.fsh
@@ -5,6 +5,8 @@ Usage: #example
 
 * meta insert HPIFacility(F38006-B)
 
+* insert LocalIdentifierExample
+
 * identifier.system = $HealthRecordKey
 * identifier.value = "f4121d2e-61aa-4222-83ae-b36d26bbbe62"
 

--- a/input/fsh/Examples/Observation-VitalSigns-example.fsh
+++ b/input/fsh/Examples/Observation-VitalSigns-example.fsh
@@ -7,8 +7,8 @@ Usage: #example
 
 * insert LocalIdentifierExample
 
-* identifier.system = $HealthRecordKey
-* identifier.value = "f4121d2e-61aa-4222-83ae-b36d26bbbe62"
+* identifier[+].system = $HealthRecordKey
+* identifier[=].value = "f4121d2e-61aa-4222-83ae-b36d26bbbe62"
 
 * code = $sct#122869004 "Measurement procedure (procedure)"
 * category = http://terminology.hl7.org/CodeSystem/observation-category#vital-signs

--- a/input/fsh/Examples/Respiratory-Condition-example.fsh
+++ b/input/fsh/Examples/Respiratory-Condition-example.fsh
@@ -6,6 +6,8 @@ Usage: #example
 
 * meta insert HPIFacility(F38006-B)
 
+* insert LocalIdentifierExample
+
 * extension.url = "http://hl7.org.nz/fhir/StructureDefinition/long-term-condition"
 * extension.valueBoolean = false
 * clinicalStatus = $condition-clinical#active

--- a/input/fsh/Examples/Respiratory-Condition-example.fsh
+++ b/input/fsh/Examples/Respiratory-Condition-example.fsh
@@ -21,7 +21,7 @@ Usage: #example
 * onsetDateTime = "2011-02-05T00:00:00+13:00"
 * recordedDate = "2023-11-26T10:02:45+13:00"
 
-* identifier.system = $HealthRecordKey
-* identifier.value = "ef5b3aad-14c2-4904-aa25-7411dcb21327"
+* identifier[+].system = $HealthRecordKey
+* identifier[=].value = "ef5b3aad-14c2-4904-aa25-7411dcb21327"
 
 * asserter insert PractitionerPerformer(99ZZZZ, Dottie McStuffins)

--- a/input/fsh/other/CapabilityHelpers.fsh
+++ b/input/fsh/other/CapabilityHelpers.fsh
@@ -43,9 +43,16 @@ RuleSet: APIStandardsDocumentation
   |:------------------|:---------|
   | `userIdentifier`  | The userid of the user as authenticated by the PMS/health application (REQUIRED) |
   | `secondaryIdentifier` | The secondary identifier for the user - this **MUST** be the end users Common Person Number (aka HPI Practitioner identifier) of the practitioner using the application (REQUIRED) |
-  | `purposeOfUse`    | Set to `"NZSCREEN"` (REQUIRED)                                                  |
+  | `purposeOfUse`    | One of [
+                                    "PATRQT",
+                                    "POPHLTH",
+                                    "TREAT",
+                                    "ETREAT",
+                                    "PUBHLTH",
+                                    "SYSDEV"
+                                ] (REQUIRED)                             |
   | `userFullName`    | Full name of the user of the PMS/health application.` (REQUIRED)    |
-  | `userRole`        | Role of the user of the PMS/health application. Set to `"PROV" (REQUIRED)                        |
+  | `userRole`        | Role of the user of the PMS/health application. Set to `"PROV" (Provider) or "PAT" (Patient) (REQUIRED)                        |
   | `orgIdentifier`   | The HPI Organisation Number (aka HPI Organisation identifier) for the organisation in which the API consumer application is deployed (REQUIRED) |
   | `facilityIdentifier` | HPI identifier for the facility where the user is located (REQUIRED) |
   
@@ -54,7 +61,7 @@ RuleSet: APIStandardsDocumentation
   #### Example Request-Context Header Payload
   **Base64 Encoded**
   ```
-  eyJ1c2VySWRlbnRpZmllciI6InBhdCIsInVzZXJSb2xlIjoiUFJPViIsInNlY29uZGFyeUlkZW50aWZpZXIiOnsidXNlIjoib2ZmaWNpYWwiLCJzeXN0ZW0iOiJodHRwczovL3N0YW5kYXJkcy5kaWdpdGFsLmhlYWx0aC5uei9ucy9ocGktcGVyc29uLWlkIiwidmFsdWUiOiI5OVpaWlMifSwicHVycG9zZU9mVXNlIjpbIlBST1YiXSwidXNlckZ1bGxOYW1lIjoiQmV2ZXJseSBDcnVzaGVyIiwib3JnSWRlbnRpZmllciI6IkcwMDAwMS1HIiwiZmFjaWxpdHlJZGVudGlmaWVyIjoiRlpaOTk5LUIifQ
+  ewogICJ1c2VySWRlbnRpZmllciI6ICJwYXQiLAogICJ1c2VyUm9sZSI6ICJQUk9WIiwKICAic2Vjb25kYXJ5SWRlbnRpZmllciI6IHsKICAgICJ1c2UiOiAib2ZmaWNpYWwiLAogICAgInN5c3RlbSI6ICJodHRwczovL3N0YW5kYXJkcy5kaWdpdGFsLmhlYWx0aC5uei9ucy9ocGktcGVyc29uLWlkIiwKICAgICJ2YWx1ZSI6ICI5OVpaWlMiCiAgfSwKICAicHVycG9zZU9mVXNlIjogWwogICAgIlBPUEhMVEgiCiAgXSwKICAidXNlckZ1bGxOYW1lIjogIkJldmVybHkgQ3J1c2hlciIsCiAgIm9yZ0lkZW50aWZpZXIiOiAiRzAwMDAxLUciLAogICJmYWNpbGl0eUlkZW50aWZpZXIiOiAiRlpaOTk5LUIiCn0=
   ```
   **Decoded JSON**
   ```json
@@ -67,7 +74,7 @@ RuleSet: APIStandardsDocumentation
     "value": "99ZZZS"
   },
   "purposeOfUse": [
-    "NZSCREEN"
+    "POPHLTH"
   ],
   "userFullName": "Beverly Crusher",
   "orgIdentifier": "G00001-G",

--- a/input/fsh/other/RuleSets.fsh
+++ b/input/fsh/other/RuleSets.fsh
@@ -37,3 +37,22 @@ RuleSet: MetaSource
 * source ^definition = "Captures the source of the record. If the record is sourced from a PMS the value should contain the HPIFacilityID
                             e.g. HPI Facility https://api.hip.digital.health.nz/fhir/Location/F38006-B
                             or HNZ System (AIR) https://api.air.digital.health.nz/fhir/"
+
+RuleSet: LocalIdentifierDocs
+* identifier 0..*
+* identifier.system 1..1
+* identifier.value 1..1
+* identifier.use ^short = "The local identifier use SHOULD be set to secondary, where the SDHR resource id is considered the primary identifier."
+* identifier.system ^short = "System for the local identifier. This MUST be consistent per PMS/Health Application"
+* identifier.value ^short = "The actual local identifier value, e.g. ec2d6cad-1e19-46ee-accf-dc460a680710"
+* identifier ^short = "A local identifier MAY be added to this section. If used, system MUST be specified."
+* identifier ^definition = "A local identifier MAY be added to this section. This can be used to correlate the SDHR resource with a local system identifier to perform updates."
+* identifier.system ^example[0].label = "Local Identifier System"
+* identifier.system ^example[0].valueUri = "https://fhir.example.co.nz"
+* identifier.value ^example[0].label = "Local Identifier Value"
+* identifier.value ^example[0].valueString = "ec2d6cad-1e19-46ee-accf-dc460a680710"
+
+RuleSet: LocalIdentifierExample
+* identifier[+].system = "https://fhir.examplepms.co.nz"
+* identifier[=].value = "ec2d6cad-1e19-46ee-accf-dc460a680710"
+* identifier[=].use = #secondary

--- a/input/fsh/profiles/AllergyIntolerance.fsh
+++ b/input/fsh/profiles/AllergyIntolerance.fsh
@@ -11,6 +11,8 @@ Description: "AllergyIntolerance FHIR resource for Shared Digital Health Record"
 * meta.source 1..1
 * meta insert MetaSource
 
+* insert LocalIdentifierDocs
+
 * contained 0..0
 * clinicalStatus from http://hl7.org/fhir/ValueSet/allergyintolerance-clinical (required)
 * verificationStatus from http://hl7.org/fhir/ValueSet/allergyintolerance-verification (required)

--- a/input/fsh/profiles/Condition.fsh
+++ b/input/fsh/profiles/Condition.fsh
@@ -7,6 +7,8 @@ Description: "Condition resource to record problems and conditions affecting a p
 * meta.source 1..1
 * meta insert MetaSource
 
+* insert LocalIdentifierDocs
+
 * onset[x] only dateTime
 
 * severity 0..0

--- a/input/fsh/profiles/Encounter.fsh
+++ b/input/fsh/profiles/Encounter.fsh
@@ -7,6 +7,8 @@ Description: "Encounter resource to record an instance of an interaction between
 * meta.source 1..1
 * meta insert MetaSource
 
+* insert LocalIdentifierDocs
+
 * statusHistory 0..0
 * classHistory 0..0
 //* type 0..0

--- a/input/fsh/profiles/Observation.fsh
+++ b/input/fsh/profiles/Observation.fsh
@@ -10,6 +10,8 @@ Description: "This profile constrains the Observation resource to represent Toba
 * meta.source 1..1
 * meta insert MetaSource
 
+* insert LocalIdentifierDocs
+
 * identifier ^slicing.discriminator.type = #value
 * identifier ^slicing.discriminator.path = "system"
 * identifier ^slicing.rules = #open

--- a/input/images-source/get-before-put.plantuml
+++ b/input/images-source/get-before-put.plantuml
@@ -1,0 +1,47 @@
+@startuml
+
+skinparam dpi 100 
+scale max 350 width
+
+skinparam ActivityDiamondBackgroundColor #RoyalBlue
+skinparam ArrowColor #RoyalBlue   
+skinparam ArrowFontColor #RoyalBlue   
+skinparam ArrowFontSize 12
+skinparam ArrowMessageAlignment right
+skinparam BoxPadding 10
+skinparam ClassFontSize 16
+skinparam ClassFontStyle bold
+skinparam ClassStereotypeFontSize 16
+skinparam dpi 300
+skinparam FooterFontSize 14
+skinparam FooterFontStyle italic
+skinparam LegendBackgroundColor #Snow
+skinparam LegendFontName Helvetica
+skinparam LegendFontSize 16
+skinparam linetype ortho
+skinparam nodesep 70
+skinparam NoteBackgroundColor #LightYellow
+skinparam NoteFontSize 15
+skinparam NoteTextAlignment left
+skinparam ranksep 60
+skinparam roundcorner 5
+skinparam TitleFontSize 20
+
+title "Shared Digital Health Record - GET before PUT"
+participant "API Consumer" as Client
+participant "SDHR FHIR Server" as Server
+
+Client -> Server: POST /Condition (Create)
+activate Server
+Server --> Client: 201 Created, serverResourceId returned
+deactivate Server
+
+note over Client, Server: Time passes, the resource has been updated at source
+
+Client -> Server: GET /Condition/{serverResourceId} (Read current resource)
+Client -> Client: Make changes to resource, e.g. update status
+Client -> Server: PUT /Condition/{serverResourceId} (Update resource)
+activate Server
+Server --> Client: 200 OK
+deactivate Server
+@enduml

--- a/input/images-source/search-by-identifier.plantuml
+++ b/input/images-source/search-by-identifier.plantuml
@@ -1,0 +1,52 @@
+@startuml
+
+skinparam dpi 100 
+scale max 350 width
+
+skinparam ActivityDiamondBackgroundColor #RoyalBlue
+skinparam ArrowColor #RoyalBlue   
+skinparam ArrowFontColor #RoyalBlue   
+skinparam ArrowFontSize 12
+skinparam ArrowMessageAlignment right
+skinparam BoxPadding 10
+skinparam ClassFontSize 16
+skinparam ClassFontStyle bold
+skinparam ClassStereotypeFontSize 16
+skinparam dpi 300
+skinparam FooterFontSize 14
+skinparam FooterFontStyle italic
+skinparam LegendBackgroundColor #Snow
+skinparam LegendFontName Helvetica
+skinparam LegendFontSize 16
+skinparam linetype ortho
+skinparam nodesep 70
+skinparam NoteBackgroundColor #LightYellow
+skinparam NoteFontSize 15
+skinparam NoteTextAlignment left
+skinparam ranksep 60
+skinparam roundcorner 5
+skinparam TitleFontSize 20
+
+title "Shared Digital Health Record - FHIR Search by identifier"
+
+participant "API Consumer" as Client
+participant "SDHR FHIR Server" as Server
+
+Client -> Server: POST /Condition (Create, including local identifier)
+activate Server
+Server --> Client: 201 Created, serverResourceId returned
+deactivate Server
+
+note over Client, Server: Time passes, the resource has been updated at source
+
+Client -> Server: **GET /Condition?identifier=https://example.org|some-local-id&_source=https://api.hip.digital.health.nz/fhir/Location/F38006-B** (Search by identifier and facilityId)
+activate Server
+Server --> Client: Bundle (Containing Condition Resource)
+deactivate Server
+Client -> Client: Make changes to resource, e.g. update status
+Client -> Server: PUT /Condition/{serverResourceId} (Update)
+activate Server
+Server --> Client: 200 OK
+deactivate Server
+
+@enduml

--- a/input/images-source/search-by-parameters.plantuml
+++ b/input/images-source/search-by-parameters.plantuml
@@ -1,0 +1,51 @@
+@startuml
+
+skinparam dpi 100 
+scale max 350 width
+
+skinparam ActivityDiamondBackgroundColor #RoyalBlue
+skinparam ArrowColor #RoyalBlue   
+skinparam ArrowFontColor #RoyalBlue   
+skinparam ArrowFontSize 12
+skinparam ArrowMessageAlignment right
+skinparam BoxPadding 10
+skinparam ClassFontSize 16
+skinparam ClassFontStyle bold
+skinparam ClassStereotypeFontSize 16
+skinparam dpi 300
+skinparam FooterFontSize 14
+skinparam FooterFontStyle italic
+skinparam LegendBackgroundColor #Snow
+skinparam LegendFontName Helvetica
+skinparam LegendFontSize 16
+skinparam linetype ortho
+skinparam nodesep 70
+skinparam NoteBackgroundColor #LightYellow
+skinparam NoteFontSize 15
+skinparam NoteTextAlignment left
+skinparam ranksep 60
+skinparam roundcorner 5
+skinparam TitleFontSize 20
+
+title "Shared Digital Health Record - FHIR Search by known parameters"
+participant "API Consumer" as Client
+participant "SDHR FHIR Server" as Server
+
+Client -> Server: POST /Condition (Create)
+activate Server
+Server --> Client: 201 Created, serverResourceId returned
+deactivate Server
+
+note over Client, Server: Time passes, the resource has been updated at source
+
+Client -> Server: **GET /Condition?code=http://snomed.info/sct|442387007&status=active&subject=https://api.hip.digital.health.nz/fhir/Patient/ZKC7284** (Search by subject, status and code)
+activate Server
+Server --> Client: Bundle (Containing Condition Resource)
+deactivate Server
+Client -> Client: Make changes to resource, e.g. update status
+Client -> Server: PUT /Condition/{serverResourceId} (Update)
+activate Server
+Server --> Client: 200 OK
+deactivate Server
+
+@enduml

--- a/input/pagecontent/api.md
+++ b/input/pagecontent/api.md
@@ -10,3 +10,51 @@ The SDHR API is comprised of multiple FHIR resources.
 {% include api-logical-overview.svg %}
 </div>
 <br clear="all">
+
+## SDHR Resource updates
+
+This section describes the process of SDHR API Consumer system interacting with the SDHR FHIR server to update existing resources.
+
+### GET before PUT
+
+To maintain data integrity, API Consumers authorized to make updates to resources must use a "GET before PUT" approach. By always fetching the current state of a resource before attempting an update, you ensure that the modifications reflect the most accurate and recent information, without overwriting updates which may have been made by other API Consumers.
+
+<div width="100%">
+<!-- Generated from `input/images-source/get-before-put.plantuml` -->
+{% include get-before-put.svg %}
+</div>
+<br clear="all">
+
+### Searching for resources before update
+
+The SDHR API reflects the FHIR Search parameters which are documented in the [Server Capability Statement](./CapabilityStatement-SDHRCapabliityStatement.html) and well as a direct HTTP GET for a resource.
+
+#### Case 1: The SDHR Server assigned resource ID is known by the API Consumer:
+
+In this scenario, an HTTP GET for the resource can be made to retrieve the resource: `GET /Condition/{serverResourceId}`.
+
+Once the update has been made, the resource can be updated in the SDHR Server by using an HTTP PUT to the resource: `PUT /Condition/{serverResourceId}`
+
+#### Case 2: The SDHR Server assigned resource ID is unknown by the API Consumer:
+
+In this scenario, a FHIR Search must be used with search parameters available to the API Consumer, as the server resource ID cannot be used for a direct HTTP GET.
+
+<b>Option 1: FHIR Search by local PMS identifier, stored as a FHIR Identifier</b>
+
+To improve accuracy in this process, API Consumers who submit or update records may append an identifier known to them to the shared record. This may be a representation or a copy of a local identifier used within the local PMS system. When a local identifier is stored, a FHIR Search using an identifier search parameter can be used to retrieve a record.
+
+<div width="100%">
+<!-- Generated from `input/images-source/search-by-identifier.plantuml` -->
+{% include search-by-identifier.svg %}
+</div>
+<br clear="all">
+
+<b>Option 2: FHIR Search using resource search parameters</b>
+
+When a local identifier is not submitted to a resource, the search parameters for each resource must be used, which are documented in the [Server Capability Statement](./CapabilityStatement-SDHRCapabliityStatement.html). This will return a FHIR Bundle which may contain multiple records which must be handled by the API Consumer.
+
+<div width="100%">
+<!-- Generated from `input/images-source/search-by-parameters.plantuml` -->
+{% include search-by-parameters.svg %}
+</div>
+<br clear="all">


### PR DESCRIPTION
- added guidance for updating SDHR resources using "GET before PUT"
- added guidance around FHIR identifier use with external systems
- added a `LocalIdentifierDocs` RuleSet to insert documentation into each SDHR Profile
- added a `LocalIdentifierExample` RuleSet to insert examples into example resources

Notes:

Adding these examples have introduced an additional build error, as the use does not match the HealthRecordKey identifier slice. Need to decide if that thinking is superseded by this.

We could possibly use `type` if we want to define a codesystem for these. The approach at the moment advises API Consumers to use a consist `system` across their implementation

Pushed to [UAT](https://fhir-ig-uat.digital.health.nz/sdhr) at 4 Apr 3.20pm
